### PR TITLE
feat: add support for fetching the latest binary based on build_type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+venv/
 inventory.yml

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ Juicity Installation with Ansible
 
 - Ansible (>= 2.15.2)
 
+## Bootstrap
+
+> **Note**
+> Running the `install` script will install all the dependencies required for the module
+
+```bash
+./install
+```
+
 ## Usage
 
 Prepare an inventory file, then customize it based on your needs.
@@ -34,6 +43,17 @@ GitHub Action: https://github.com/juicity/juicity/actions
 > ONLY works for GitHub Action builds, not available for stable releases at the moment.
 
 ```bash
+# install binary from the build_type: {latest pr-build,main-build,daily-build}
+# use default build_type: pr-build
+./scripts/update
+
+# build_type: main
+./scripts/update build
+
+# build_type: daily-build
+./scripts/update daily-build
+
+# install binary from a given github action url
 ./scripts/update <github_action_url>
 # e.g
 ./scripts/update https://github.com/juicity/juicity/actions/runs/5927920609

--- a/install
+++ b/install
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -ex
+
+top=$(cd $(dirname $0); pwd)
+python3 -m venv ${top}/venv
+
+${top}/venv/bin/pip3 install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyGithub
 ansible
+PyGithub

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyGithub
+ansible

--- a/roles/juicity.update/library/github_workflow_run.py
+++ b/roles/juicity.update/library/github_workflow_run.py
@@ -22,7 +22,7 @@ def main():
         build_type=dict(type="str", required=True),
     )
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
-    result = dict(changed=False, run_id=0)
+    result = dict(changed=True, run_id=0)
 
     m = Module(module.params["owner"], module.params["repo"])
     latest_run_id = m.get_latest_workflow_run_id(module.params["build_type"])

--- a/roles/juicity.update/library/github_workflow_run.py
+++ b/roles/juicity.update/library/github_workflow_run.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python
+
+from ansible.module_utils.basic import AnsibleModule
+from github import Github
+
+
+class Module:
+    def __init__(self, repo_owner: str, repo_name: str) -> None:
+        self.github = Github()
+        self.repo = self.github.get_repo(f"{repo_owner}/{repo_name}")
+
+    def get_latest_workflow_run_id(self, build_type: str) -> int:
+        workflow = self.repo.get_workflow(f"{build_type}.yml")
+        # Runs are returned in descending order.
+        return workflow.get_runs()[0].id
+
+
+def main():
+    module_args = dict(
+        owner=dict(type="str", required=True),
+        repo=dict(type="str", required=True),
+        build_type=dict(type="str", required=True),
+    )
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+    result = dict(changed=False, run_id=0)
+
+    m = Module(module.params["owner"], module.params["repo"])
+    latest_run_id = m.get_latest_workflow_run_id(module.params["build_type"])
+    result["run_id"] = latest_run_id
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/juicity.update/tasks/update.yml
+++ b/roles/juicity.update/tasks/update.yml
@@ -6,14 +6,36 @@
         name: unzip
         state: present
 
-- name: Extract run_id from input url
+- name: Fetch latest run_id from the given build_type
+  block:
+    - name: Fetch latest run_id from the given build_type
+      github_workflow_run:
+        owner: juicity
+        repo: juicity
+        build_type: "{{ build_type }}"
+      delegate_to: localhost
+      register: result
+      become: false
+    - name: Extract run_id from outputs
+      set_fact:
+        run_id: "{{ result.run_id }}"
+  when:
+    - build_type == "pr-build"
+    - latest
+    - action_url is not defined
+
+- name: Extract run_id from action_url
   set_fact:
     run_id: "{{ action_url | split('/') | last }}"
+  when:
+    - action_url is defined
+    - build_type == "custom"
 
 - name: Download binary from GitHub Actions
   get_url:
     url: "{{ base_url }}/{{ run_id }}/juicity-linux-x86_64.zip"
     dest: /tmp/juicity.zip
+  register: download
 
 - name: unzip juicity.zip
   unarchive:
@@ -32,6 +54,7 @@
   systemd:
     name: "{{ systemd_service }}"
     state: restarted
+  when: download.changed
 
 - name: Verify version
   block:
@@ -42,4 +65,5 @@
     - name: Print output
       debug:
         msg: "{{ version.stdout }}"
+  when: download.changed
 

--- a/roles/juicity.update/tasks/update.yml
+++ b/roles/juicity.update/tasks/update.yml
@@ -15,10 +15,10 @@
         build_type: "{{ build_type }}"
       delegate_to: localhost
       register: result
-      become: false
     - name: Extract run_id from outputs
       set_fact:
         run_id: "{{ result.run_id }}"
+  become: false
   when:
     - build_type is defined
     - latest

--- a/roles/juicity.update/tasks/update.yml
+++ b/roles/juicity.update/tasks/update.yml
@@ -20,7 +20,7 @@
       set_fact:
         run_id: "{{ result.run_id }}"
   when:
-    - build_type == "pr-build"
+    - build_type is defined
     - latest
     - action_url is not defined
 

--- a/roles/juicity.update/tasks/update.yml
+++ b/roles/juicity.update/tasks/update.yml
@@ -15,10 +15,10 @@
         build_type: "{{ build_type }}"
       delegate_to: localhost
       register: result
+      become: false
     - name: Extract run_id from outputs
       set_fact:
         run_id: "{{ result.run_id }}"
-  become: false
   when:
     - build_type is defined
     - latest

--- a/scripts/update
+++ b/scripts/update
@@ -1,10 +1,19 @@
 #!/bin/bash
 
-set -ex
+set -e
 
-action_url=$1
+BIN="venv/bin/ansible-playbook"
 
-ansible-playbook -i inventory.yml \
-  --extra-vars "action_url=$action_url" \
-  update.yml
-
+if [ -z "$1" ] && [[ "$1" != *"http://"* ]]; then
+  [[ ! -z "$1" ]] && build_type=$1 || build_type=pr-build
+  $BIN -i inventory.yml \
+    --extra-vars "build_type=$build_type" \
+    --extra-vars "latest=true" \
+    update.yml
+else
+  action_url=$1
+  $BIN -i inventory.yml \
+    --extra-vars "action_url=$action_url" \
+    --extra-vars "build_type=custom" \
+    update.yml
+fi

--- a/update.yml
+++ b/update.yml
@@ -4,8 +4,9 @@
   become: true
 
   vars:
-    base_url: "https://nightly.link/juicity/juicity/actions/runs"
     systemd_service: juicity-server
+    type: pr-build # options: [main-build, pr-build]
+    latest: true
 
   roles:
     - role: ./roles/juicity.update/

--- a/update.yml
+++ b/update.yml
@@ -5,8 +5,6 @@
 
   vars:
     systemd_service: juicity-server
-    type: pr-build # options: [main-build, pr-build]
-    latest: true
 
   roles:
     - role: ./roles/juicity.update/


### PR DESCRIPTION
## Summary

As the title suggests.

## How to run

Case 1: download binary from the build_type: {latest pr-build,main-build,daily-build}

default `build_type`: `pr-build`

```bash
# use default build_type
./scripts/update

# build_type: main
./scripts/update build

# build_type: daily-build
./scripts/update daily-build
```

Case 2: download binary from a given github action url

```bash
./scripts/update https://github.com/juicity/juicity/actions/runs/5977799118
```

## Changelogs

- ci: add bootstrap script
- ci(script): add condition for custom-build-type
- feat: add support for fetching the latest pr-build;main-build
- chore(gitignore): update ignore list
- docs: update README

## Test results

Case 1:

![image](https://github.com/juicity/ansible-juicity-install/assets/31861128/640b82ee-3437-472b-9de9-66cda8c28b5a)

![image](https://github.com/juicity/ansible-juicity-install/assets/31861128/a1812807-714f-4442-bdb0-e3be0b868888)

Case 2:

![image](https://github.com/juicity/ansible-juicity-install/assets/31861128/640b82ee-3437-472b-9de9-66cda8c28b5a)
