### PR TITLE
feat: add juicity.restart role

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,16 @@ GitHub Action: https://github.com/juicity/juicity/actions
 # e.g
 ./scripts/update https://github.com/juicity/juicity/actions/runs/5927920609
 ```
+
+### Juicity Server Restart
+
+```bash
+# restart all remote hosts
+./scripts/restart
+
+# exclude particular host(s), separate with comma
+./scripts/restart --limit '!host1,!host2'
+
+# include particular host(s), separate with comma
+./scripts/restart --limit 'host1,host2'
+```

--- a/restart.yml
+++ b/restart.yml
@@ -1,0 +1,10 @@
+- name: Restart juicity on remote hosts
+  hosts: all
+  gather_facts: true
+  become: true
+
+  vars:
+    systemd_service: juicity-server
+
+  roles:
+    - role: ./roles/juicity.restart/

--- a/roles/juicity.restart/defaults/main.yml
+++ b/roles/juicity.restart/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+systemd_service: juicity-server

--- a/roles/juicity.restart/tasks/main.yml
+++ b/roles/juicity.restart/tasks/main.yml
@@ -1,0 +1,1 @@
+- import_tasks: ./restart.yml

--- a/roles/juicity.restart/tasks/restart.yml
+++ b/roles/juicity.restart/tasks/restart.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart systemd service
+  systemd:
+    name: "{{ systemd_service }}"
+    state: restarted

--- a/roles/juicity.update/tasks/update.yml
+++ b/roles/juicity.update/tasks/update.yml
@@ -21,7 +21,7 @@
         run_id: "{{ result.run_id }}"
   when:
     - build_type is defined
-    - latest
+    - latest is defined
     - action_url is not defined
 
 - name: Extract run_id from action_url

--- a/scripts/restart
+++ b/scripts/restart
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+BIN="venv/bin/ansible-playbook"
+args=$@
+
+$BIN -i inventory.yml \
+  $args \
+  restart.yml


### PR DESCRIPTION
## Summary

Add restart functionality

## Usage

```bash
# restart all remote hosts
./scripts/restart

# exclude particular host(s), separate with comma
./scripts/restart --limit '!host1,!host2'

# include particular host(s), separate with comma
./scripts/restart --limit 'host1,host2'
```

## Test Results

<img width="640" alt="image" src="https://github.com/juicity/ansible-juicity-install/assets/31861128/fc19d73f-a2eb-4b0c-9af7-40125826e5f0">
